### PR TITLE
Issue 4

### DIFF
--- a/src/LoopbackClient.js
+++ b/src/LoopbackClient.js
@@ -73,7 +73,7 @@ class LoopbackClient {
         })
           .then(handleErrors)
           .then(result => {
-            this.token = result.id;
+            this.token = result.id || result.data.id;
 
             debug('r=',result)
             resolve(result.id);

--- a/src/LoopbackClient.js
+++ b/src/LoopbackClient.js
@@ -76,7 +76,7 @@ class LoopbackClient {
             this.token = result.id || result.data.id;
 
             debug('r=',result)
-            resolve(result.id);
+            resolve(this.token);
           })
           .catch(error => {            
             reject(error);


### PR DESCRIPTION
Addressed an issue when calling createToken against a custom login path.  The HTTP POST request worked fine, but the token ID come back as part of the result.data object and not the result.  In case there are other variations where the token is set in result.id, this code fix just checks for both.